### PR TITLE
Feat/add review form

### DIFF
--- a/app/controllers/api/internal/reviews_controller.rb
+++ b/app/controllers/api/internal/reviews_controller.rb
@@ -1,0 +1,16 @@
+class Api::Internal::ReviewsController < Api::Internal::BaseController
+  before_action :authenticate_user!
+
+  def create
+    respond_with Review.create!(review_params.merge(user: current_user))
+  end
+
+  private
+
+  def review_params
+    params.require(:review).permit(
+      :item_id,
+      :body
+    )
+  end
+end

--- a/app/controllers/app/items_controller.rb
+++ b/app/controllers/app/items_controller.rb
@@ -15,7 +15,7 @@ class App::ItemsController < App::BaseController
   end
 
   def reviews
-    @reviews ||= item.reviews.includes([:user])
+    @reviews ||= item.reviews.order(created_at: :desc).includes([:user])
   end
 
   def item_params

--- a/app/javascript/api/reviews.ts
+++ b/app/javascript/api/reviews.ts
@@ -1,3 +1,4 @@
+import api from './index';
 import type { User } from './users';
 import type { Item } from './items';
 
@@ -9,3 +10,22 @@ export interface Review {
   createdAt: string;
   updatedAt: string;
 }
+
+export type ReviewForm = {
+  itemId: number;
+  body: string | null,
+};
+
+export default {
+  create(review: ReviewForm) {
+    const path = '/api/internal/reviews';
+
+    return api({
+      method: 'post',
+      url: path,
+      data: {
+        review,
+      },
+    });
+  },
+};

--- a/app/javascript/components/base-button.vue
+++ b/app/javascript/components/base-button.vue
@@ -5,6 +5,7 @@ const variants = {
   danger: 'bg-rose-400 hover:bg-rose-500 text-white',
   success: 'bg-green-400 text-white hover:bg-green-500',
   disabled: 'bg-zinc-500 text-white cursor-not-allowed',
+  cancel: 'bg-transparent text-zinc-800',
 };
 
 interface Props {
@@ -20,7 +21,7 @@ withDefaults(
 
 <template>
   <button
-    class="rounded-full px-4 py-2 text-sm font-semibold"
+    class="rounded-full px-4 py-2 text-lg font-semibold"
     :class="variants[variant]"
   >
     <slot />

--- a/app/javascript/components/base-input.vue
+++ b/app/javascript/components/base-input.vue
@@ -34,7 +34,7 @@ export default {
   >
     <span class="font-normal text-zinc-800">{{ label }}</span>
     <input
-      class="rounded border-zinc-300 bg-white focus:ring-blue-800"
+      class="rounded border border-zinc-300 bg-white py-2 px-3 focus:ring-blue-800"
       v-bind="attrsWithoutClasses"
       @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
     >

--- a/app/javascript/components/item-show-review-form.vue
+++ b/app/javascript/components/item-show-review-form.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { reactive, ref } from 'vue';
+import { useNotification } from '@kyvg/vue3-notification';
+import reviewsApi, { type ReviewForm } from '../api/reviews';
+import type { Item } from '../api/items';
+
+type Props = {
+  item: Item
+};
+
+const props = defineProps<Props>();
+
+const form = reactive({
+  itemId: props.item.id,
+  body: '',
+} as ReviewForm);
+
+defineEmits<{(e: 'closeReviewForm'): void}>();
+
+const loading = ref(false);
+
+const { notify } = useNotification();
+
+async function writeReview() {
+  loading.value = true;
+  try {
+    await reviewsApi.create(form);
+    notify({ text: 'Gracias por tu comentario!', type: 'success' });
+  } catch (error) {
+    notify({ text: 'Ups, ocurrió un error! Inténtalo de nuevo', type: 'error' });
+  } finally {
+    window.location.href = `/items/${form.itemId}`;
+  }
+}
+
+</script>
+<template>
+  <form
+    class="flex flex-col items-center gap-3 py-2.5 px-2"
+    @submit.prevent="writeReview"
+  >
+    <p class="text-base text-zinc-800">
+      Qué te pareció el producto?
+    </p>
+    <p class="text-base text-zinc-800">
+      Agrega un comentario
+    </p>
+    <base-input
+      v-model="form.body"
+      placeholder="Escriba su reseña aquí"
+      name="body"
+      class="w-80"
+    />
+    <div class="flex w-80 flex-row gap-4">
+      <base-button
+        type="button"
+        class="w-full"
+        variant="cancel"
+        @click="$emit('closeReviewForm')"
+      >
+        Cancel
+      </base-button>
+      <base-button
+        type="submit"
+        class="w-full rounded-lg"
+      >
+        Enviar
+      </base-button>
+    </div>
+  </form>
+</template>

--- a/app/javascript/components/item-show-review-write.vue
+++ b/app/javascript/components/item-show-review-write.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { Item } from '../api/items';
+
+type Props = {
+  item: Item
+};
+defineProps<Props>();
+
+defineEmits<{(e: 'openReviewForm'): void}>();
+</script>
+<template>
+  <div class="flex w-full flex-col items-center">
+    <p class="text-base text-zinc-800">
+      Cómo te fue con el producto?
+    </p>
+    <base-button
+      class="w-full border"
+      variant="secondary"
+      @click="$emit('openReviewForm')"
+    >
+      Escribir mi opinión
+    </base-button>
+  </div>
+</template>

--- a/app/javascript/components/item-show-review.vue
+++ b/app/javascript/components/item-show-review.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
+import { ref } from 'vue';
+import type { Item } from '../api/items';
 import type { Review } from '../api/reviews';
+import ItemShowReviewWrite from './item-show-review-write.vue';
+import ItemShowReviewForm from './item-show-review-form.vue';
 import ItemShowReviewList from './item-show-review-list.vue';
 
 type Props = {
+  item: Item
   reviews: Review[]
 };
 defineProps<Props>();
 
+const showReviewForm = ref(false);
 </script>
 
 <template>
@@ -14,7 +20,19 @@ defineProps<Props>();
     <span class="text-xl font-bold text-zinc-800">
       Opiniones del producto
     </span>
+    <div class="flex w-full gap-16">
+      <item-show-review-write
+        v-if="!showReviewForm"
+        :item="item"
+        @open-review-form="showReviewForm = true"
+      />
+    </div>
     <hr class="border-t border-zinc-800">
+    <item-show-review-form
+      v-if="showReviewForm"
+      :item="item"
+      @close-review-form="showReviewForm = false"
+    />
     <item-show-review-list
       :reviews="reviews"
     />

--- a/app/serializers/api/internal/review_serializer.rb
+++ b/app/serializers/api/internal/review_serializer.rb
@@ -2,6 +2,7 @@ class Api::Internal::ReviewSerializer < ActiveModel::Serializer
   type :review
 
   belongs_to :user
+  belongs_to :item
 
   attributes(
     :id,

--- a/app/views/app/items/show.html.erb
+++ b/app/views/app/items/show.html.erb
@@ -9,6 +9,7 @@
   <item-show-detail :item="<%= serialize_resource(@item) %>">
   </item-show-detail>
   <item-show-review
+    :item="<%= serialize_resource(@item) %>"
     :reviews="<%= serialize_resource(@reviews) %>"
   >
   </item-show-review>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     namespace :internal do
       resources :purchases, only: [:index, :create, :show]
       resources :items, only: [:index, :show]
+      resources :reviews, only: [:create]
     end
   end
   devise_for :users

--- a/spec/requests/api/internal/reviews_spec.rb
+++ b/spec/requests/api/internal/reviews_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Internal::ReviewsControllers", type: :request do
+  let(:item) { create(:item) }
+  let(:user) { create(:user) }
+
+  describe 'POST /create' do
+    let(:params) { { item_id: item.id, body: Faker::Lorem.words } }
+
+    let(:attributes) do
+      JSON.parse(response.body)['review'].symbolize_keys
+    end
+
+    def perform
+      post '/api/internal/reviews', params: { review: params }
+    end
+
+    it { expect(Review.count).to eq(0) }
+
+    context 'with authorized user' do
+      before do
+        sign_in(user)
+        perform
+      end
+
+      it 'creates a review' do
+        expect(Review.count).to eq(1)
+      end
+
+      it { expect(attributes[:item]["id"]).to eq(item.id) }
+      it { expect(attributes[:user]["id"]).to eq(user.id) }
+      it { expect(response.status).to eq(201) }
+    end
+
+    context 'with unauthenticated user' do
+      before { perform }
+
+      it { expect(response.status).to eq(401) }
+    end
+  end
+end


### PR DESCRIPTION
### Contexto

The Store es una tienda de muebles. Se quiere poder agregar reseñas a cada producto y que se vean en el detalle de cada uno. Para esto, al tener el modelo Review y la lista de reviews de un producto, se agrega el formulario para crear un comentario en el detalle de cada producto.

### Qué se esta haciendo

- Se crea el controlador de `Reviews`  en `api`, el cual sólo tiene create, ya que es lo único que se necesita ahora. Se tiene su respectivo test.
- En `api/Reviews.ts` se agrega `create` para poder crear una nueva Review desde el componente vue
- Se modifica `base-input` para que sea como en Figma.
- Se modifica `base-button` para agregar la variante `cancel` para el botón cancelar del formulario.
- Se agregan las rutas de reviews api
- Se modifica el componente `item-show-review` para agregar los componentes del formulario. Se agrega el prop `item`.
- Se crea `item-show-review-write` para la vista que contiene al botón que abre el formulario.
- Se crea `item-show-review-form` que contiene el formulario para crear una Review. El botón `cancel` desaparece el formulario y vuelve a aparecer `item-show-review-write`.
- Se vuelve a agregar belongs_to :item al serializer de reviews para poder testear que es el item asociado a review es el que corresponde. 
#### En particular hay que revisar


-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
![Captura de Pantalla 2023-01-06 a la(s) 19 05 42](https://user-images.githubusercontent.com/50721272/211108160-cf31f332-fe19-4f50-be87-b8fd1c6de3a9.png)
![Captura de Pantalla 2023-01-06 a la(s) 19 05 49](https://user-images.githubusercontent.com/50721272/211108163-bbb136fa-00aa-4f33-bfb6-255ba45d7eb9.png)

https://user-images.githubusercontent.com/50721272/211108165-6c128134-5671-4dd6-8bec-93f1da9ad92c.mov

